### PR TITLE
Add workflow for creating ZIP file on release

### DIFF
--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -1,0 +1,29 @@
+name: Generate Installable Plugin, and Upload as Release Asset
+on:
+  release:
+    types: [published]
+jobs:
+  build:
+    name: Upload Release Asset
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: setup git config
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "<>"
+      - name: Create artifact
+        run : |
+          git archive -o cp-wpvmod.zip --prefix cp-wpvmod/ HEAD 
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+            name: cp-wpvmod
+            path: cp-wpvmod.zip
+      - name: Upload to release
+        uses: JasonEtco/upload-to-release@master
+        with:
+          args: cp-wpvmod.zip application/zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
To create a release with this:
- Go to "Releases" in the repo
- Click on "Draft a new release"
- Tag the release as the plugin release and choose to create new tag on publish

<img width="332" alt="image" src="https://github.com/EliteStarServices/cp-wpvmod/assets/29772709/b13610eb-b22d-476a-9429-fd803795f9d3">

- Give it a title

<img width="459" alt="image" src="https://github.com/EliteStarServices/cp-wpvmod/assets/29772709/de0485ea-814e-4835-9367-d5a34820ac93">


- Publish release

<img width="398" alt="image" src="https://github.com/EliteStarServices/cp-wpvmod/assets/29772709/1380fc2b-626e-48ce-8a9a-caca75c698fa">
